### PR TITLE
New VAT standard rates 2017

### DIFF
--- a/plans/taxation/eu.py
+++ b/plans/taxation/eu.py
@@ -33,7 +33,7 @@ class EUTaxationPolicy(TaxationPolicy):
         'DK': Decimal('25'),  # Denmark
         'DE': Decimal('19'),  # Germany
         'EE': Decimal('20'),  # Estonia
-        'EL': Decimal('23'),  # Greece
+        'EL': Decimal('24'),  # Greece
         'ES': Decimal('21'),  # Spain
         'FR': Decimal('20'),  # France
         'HR': Decimal('25'),  # Croatia
@@ -42,14 +42,14 @@ class EUTaxationPolicy(TaxationPolicy):
         'CY': Decimal('19'),  # Cyprus
         'LV': Decimal('21'),  # Latvia
         'LT': Decimal('21'),  # Lithuania
-        'LU': Decimal('15'),  # Luxembourg
+        'LU': Decimal('17'),  # Luxembourg
         'HU': Decimal('27'),  # Hungary
         'MT': Decimal('18'),  # Malta
         'NL': Decimal('21'),  # Netherlands
         'AT': Decimal('20'),  # Austria
         'PL': Decimal('23'),  # Poland
         'PT': Decimal('23'),  # Portugal
-        'RO': Decimal('24'),  # Romania
+        'RO': Decimal('19'),  # Romania
         'SI': Decimal('22'),  # Slovenia
         'SK': Decimal('20'),  # Slovakia
         'FI': Decimal('24'),  # Finland


### PR DESCRIPTION
As of 1st of January 2017, two VAT rates have changed : Luxembourg (from 15 to 17%) and Romania (from 20% to 19% - Romania changed from 24% to 20% in 2016), Greece from 23% to 24% (changed in 2016)